### PR TITLE
Use `MutationObserver` when watching for list changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ti-ember-sortable",
   "description": "Sortable lists for Ember.js.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Chris McC",
   "license": "MIT",
   "repository": {

--- a/ti-ember-sortable.js
+++ b/ti-ember-sortable.js
@@ -14,6 +14,7 @@ var TiEmberSortable = Ember.Component.extend({
   draggableSelector: 'li',
   isDisabled: false,
   model: null,
+  mutationObserver: null,
   classNameBindings: [
     ':ember-sortable',
     'isDisabled:ember-sortable--disabled:ember-sortable--enabled'
@@ -42,9 +43,10 @@ var TiEmberSortable = Ember.Component.extend({
   watchForListChanges: function() {
     var _this = this;
 
-    this.$().on('DOMNodeInserted', function() {
-      Ember.run.debounce(_this, _this.assignIds, 50);
-    });
+    const observer = new MutationObserver(() => Ember.run.debounce(_this, _this.assignIds, 50));
+    observer.observe(this.$()[0], { childList: true });
+
+    this.set('mutationObserver', observer);
   }.on('didInsertElement'),
 
   // assign ids for later detached element matching
@@ -131,6 +133,13 @@ var TiEmberSortable = Ember.Component.extend({
       } catch (e) {
         // ignore
       }
+    }
+  }.on('willDestroyElement'),
+
+  destroyMutationObserver: function () {
+    const observer = this.get('mutationObserver');
+    if (observer) {
+      observer.disconnect();
     }
   }.on('willDestroyElement')
 });


### PR DESCRIPTION
Currently, on Chrome, you can only reorder the list once before breaking the component. Any subsequent re-orderings are not saved and cause unexpected behavior on the frontend.

This is due to the observer `watchForListChanges` using the listener `DOMNodeInserted`, which was [deprecated and removed from Chrome in July 2024](https://developer.chrome.com/blog/mutation-events-deprecation).

This updates the observer to use [MutationObserver](https://developer.chrome.com/blog/mutation-events-deprecation#use_mutationobserver_instead) instead.